### PR TITLE
Reset built-in duotone and gradient presets

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -43,6 +43,8 @@
       "custom": false,
       "link": true,
       "defaultPalette": false,
+      "duotone": [],
+      "gradients": [],
       "palette": [
         {
           "slug": "white",


### PR DESCRIPTION
Adding the empty arrays for `gradients` and `duotone` in the settings block of theme.json removes all of the presets from the editor. We'll leave them empty for now and consider art-directed custom presets later on.