### PR TITLE
Site title refactoring

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -152,8 +152,9 @@ function ucsc_logo_switch($block_content = '', $block = [])
 add_filter('render_block', 'ucsc_logo_switch', 10, 2);
 
 /**
- * Change site Html Structure
- * Adjust templates to conform to UCSC semantics
+ * Set accessible HTML headers
+ * The site title is the `h1` on the home page and `p` on all other pages.
+ * The page title is the `h1` on all other pages.
  *
  * @param  string $block_content Block content to be rendered.
  * @param  array  $block         Block attributes.
@@ -161,46 +162,16 @@ add_filter('render_block', 'ucsc_logo_switch', 10, 2);
  */
 function ucsc_adjust_structure($block_content = '', $block = [])
 {
-	if (is_front_page() && is_home()) {
-		// Default homepage
+	if (is_front_page()) {
+		// On the home page, return the block as is
 		$html = $block_content;
 		return $html;
-	} elseif (is_front_page()) {
-		// Static homepage
-		if (isset($block['blockName']) && 'core/post-title' === $block['blockName']) {
-			$html = '';
-			return $html;
-		}
-	} elseif (is_home()) {
-
-		// Blog page
-		$html = $block_content;
-		return $html;
-	} elseif (is_archive() || is_search()) {
-
-		// Archive page
-		if (isset($block['blockName']) && 'core/site-title' === $block['blockName']) {
-			$html = str_replace(
-				'<h1 ',
-				'<p ',
-				$block_content
-			);
-			return $html;
-		}
 	} else {
-		// all other pages
+		// On all other pages, the site title becomes `p` and page title becomes `h1`
 		if (isset($block['blockName']) && 'core/site-title' === $block['blockName']) {
 			$html = str_replace(
 				'<h1 ',
 				'<p ',
-				$block_content
-			);
-			return $html;
-		}
-		if (isset($block['blockName']) && 'core/post-title' === $block['blockName']) {
-			$html = str_replace(
-				'<h2 ',
-				'<h1 ',
 				$block_content
 			);
 			return $html;
@@ -209,3 +180,6 @@ function ucsc_adjust_structure($block_content = '', $block = [])
 	return $block_content;
 }
 add_filter('render_block', 'ucsc_adjust_structure', 10, 2);
+
+
+

--- a/parts/content-archive-search.html
+++ b/parts/content-archive-search.html
@@ -1,7 +1,7 @@
 
 <!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-title {"level":2,"isLink":true} /-->
 
 <!-- wp:post-date /-->
 

--- a/parts/header.html
+++ b/parts/header.html
@@ -14,12 +14,17 @@
 			padding-left: 0px;
 		"
 	>
+
 		<!-- wp:group {"className":"campus-name secondary-name"} -->
-<div class="wp-block-group campus-name secondary-name"><!-- wp:site-title {"tagName":"p","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"600","lineHeight":"1.2"}}} /--></div>
+		<div class="wp-block-group campus-name secondary-name">
+			<!-- wp:site-title {"level":3} /-->
+		</div>
+		<!-- /wp:group -->
+
+</div>
 <!-- /wp:group -->
-	</div>
-	<!-- /wp:group -->
 
 	<!-- wp:navigation {"textColor":"ucsc-primary-blue","className":"main-navigation","style":{"typography":{"fontStyle":"normal","fontWeight":"500","textTransform":"capitalize","fontSize":"1.1rem"}}} /-->
+
 </div>
 <!-- /wp:group -->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","className":"site-content","layout":{"inherit":true}} -->
 <main class="wp-block-group site-content">
-	<!-- wp:query-title {"type":"archive"} /-->
+	<!-- wp:query-title {"level":1, "type":"archive"} /-->
 
 	<!-- wp:query-loop -->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,31 +1,41 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
 
 <!-- wp:group {"tagName":"main","className":"site-content","layout":{"inherit":true}} -->
-<main class="wp-block-group site-content"><!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
+<main class="wp-block-group site-content">
+<!-- wp:heading {"level":1} -->
+<h1 id="news">News</h1>
+<!-- /wp:heading -->
+
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
+<div class="wp-block-query">
+<!-- wp:post-template -->
+
+<!-- wp:post-title {"isLink":true, "level":2} /-->
 <!-- wp:post-date /-->
 
-<!-- wp:post-title {"isLink":true} /-->
-
 <!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-columns">
+<!-- wp:column {"width":"66.66%"} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:post-excerpt /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"33.33%"} -->
 <div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:post-featured-image {"align":"center","style":{"color":[]}} /--></div>
-<!-- /wp:column --></div>
+<!-- /wp:column -->
+</div>
 <!-- /wp:columns -->
 <!-- /wp:post-template -->
 
 <!-- wp:query-pagination -->
 <!-- wp:query-pagination-previous /-->
-
 <!-- wp:query-pagination-numbers /-->
-
 <!-- wp:query-pagination-next /-->
-<!-- /wp:query-pagination --></div>
-<!-- /wp:query --></main>
+<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:query -->
+
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header", "className":"site-header"} /-->
 <!-- wp:group {"layout":{"inherit":true},"tagName":"main", "className":"site-content"} -->
 <main class="wp-block-group site-content">
-<!-- wp:post-title /-->
+<!-- wp:post-title {"level":1} /-->
 <!-- wp:post-content /-->
 </main>
 <!-- /wp:group -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","className":"site-content","layout":{"inherit":true}} -->
 <main class="wp-block-group site-content">
-<h1>Search results</h1>
-	<!-- wp:query-title {"type":"search"} /-->
+
+<h1 class="wp-block-post-title">Search results</h1>
 
 	<!-- wp:query-loop -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header", "className":"site-header"} /-->
 <!-- wp:group {"layout":{"inherit":true},"tagName":"main", "className":"site-content"} -->
 <main class="wp-block-group site-content">
-	<!-- wp:post-title /-->
+	<!-- wp:post-title {"level":1} /-->
 	<!-- wp:post-author /-->
 	<!-- wp:post-date /-->
 	<!-- wp:post-featured-image /-->


### PR DESCRIPTION
This PR continues the work done previously, but changes page, post, and query titles tags to use block attributes instead of filter functions in PHP.

Reference: https://developer.wordpress.org/themes/block-themes/templates-and-template-parts/#block-markup 