### PR TITLE
Add excerpt support to Pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -359,3 +359,8 @@ function ucsc_truss_assets() { ?>
 
 <?php
 }
+
+/**
+ * Add Excerpts to Pages
+ */
+add_post_type_support( 'page', 'excerpt' );


### PR DESCRIPTION
Added excerpt functionality to Pages via `add_post_type_support( 'page', 'excerpt' );` Fixes #233 