### PR TITLE
fix: :bug: Dashicons are not showing on the front-end when logged out

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,6 +123,7 @@ function ucsc_scripts()
 		'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,600,700,800&display=swap',
 		false
 	);
+	wp_enqueue_style( 'dashicons' );
 	wp_register_script(
 		'ucsc-front',
 		get_template_directory_uri() . '/build/theme.js',


### PR DESCRIPTION
## What does this do/fix?

Fixes #333

## QA

Links to relevant issues
- #333 

Links to deployed, scaffolded demo:
- [Link to Demo](https://jasonchafin.com/wordpress-resources-at-greengeeks/)
I cold not replicate this bug in my Local Dev. Logging out of my local install still worked fine. I needed to test on a live site, so I installed the UCSC Theme to jasonchafin.com, activated, and tested a Details block. Scroll to bottom of the page.

## Tests

Does this have tests?

- [ x ] Yes, tested on live site, logged out. See link to demo.

