### PR TITLE
Feat: Add full-page patterns for example Home, About, and Topic pages

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -25,6 +25,11 @@ add_action('init', function () {
 	);
 
 	register_block_pattern_category(
+		'examples',
+		array('label' => __('Page Examples', 'ucsc'))
+	);
+
+	register_block_pattern_category(
 		'grid',
 		array('label' => __('Grid', 'ucsc'))
 	);

--- a/patterns/example-page-about.php
+++ b/patterns/example-page-about.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Title: About Page
+ * Slug: ucsc-2022/about-page
+ * Categories: examples
+ */
+?>
+
+<!-- wp:group {"align":"full","className":"ucsc-page-header","layout":{"type":"default"},"fontSize":"base"} -->
+<div class="wp-block-group alignfull ucsc-page-header has-base-font-size"><!-- wp:cover {"url":"https://sandbox.wordpress.ucsc.edu/files/2023/10/9-13-21-Hummingbird-CL-007-3-1.jpg","id":1373,"alt":"Hummingbird","dimRatio":0,"minHeight":570,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"className":"ucsc-page-header__content"} -->
+<div class="wp-block-cover is-light ucsc-page-header__content" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:0;min-height:570px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-1373" alt="Hummingbird" src="https://sandbox.wordpress.ucsc.edu/files/2023/10/9-13-21-Hummingbird-CL-007-3-1.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"default"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"ucsc-primary-yellow","textColor":"ucsc-primary-blue","className":"ucsc-page-header__title primary-post-title","fontSize":"seven"} /--></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"var:preset|spacing|40"}},"border":{"width":"0px","style":"none","radius":"0px"}}} -->
+<div class="wp-block-columns alignfull" style="border-style:none;border-width:0px;border-radius:0px;margin-top:0;margin-bottom:var(--wp--preset--spacing--40);padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph {"align":"center","backgroundColor":"ucsc-primary-blue","textColor":"white","className":"is-style-ucsc-intro-text"} -->
+<p class="has-text-align-center is-style-ucsc-intro-text has-white-color has-ucsc-primary-blue-background-color has-text-color has-background">Use this block to write copy that will set the tone and give a high-level introduction to the page content/topic.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"right":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--30);flex-basis:66.66%"><!-- wp:paragraph {"align":"center","backgroundColor":"ucsc-violator-yellow","className":"is-style-success"} -->
+<p class="has-text-align-center is-style-success has-ucsc-violator-yellow-background-color has-background"><strong>Web editor! Looking for web writing best practices to match this page? </strong><a href="https://websites.ucsc.edu/guides/showcase/pattern-about-page/" data-type="page" data-id="2066">You can find them here.</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">H2 Subhead</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"is-style-ucsc-intro-text"} -->
+<p class="is-style-ucsc-intro-text">This text starts to get more specific to the content of the page. It is an intro and should not be more than five sentences.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This level copy gets more granular and can be much longer. You can break it up with a video or photo and make it as long as needed to communicate your message. Remember, when you're promoting something on the web, it's best to use as few words as possible.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:embed {"url":"https://youtu.be/2NsDyg3A42o?si=aUXkPSV4fDxlyxw8","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio" style="margin-top:var(--wp--preset--spacing--30)"><div class="wp-block-embed__wrapper">
+https://youtu.be/2NsDyg3A42o?si=aUXkPSV4fDxlyxw8
+</div></figure>
+<!-- /wp:embed -->
+
+<!-- wp:separator {"backgroundColor":"lightest-gray"} -->
+<hr class="wp-block-separator has-text-color has-lightest-gray-color has-alpha-channel-opacity has-lightest-gray-background-color has-background"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">Meet the team</h2>
+<!-- /wp:heading -->
+
+<!-- wp:ucscblocks/campusdirectory {"pageLayout":"tiled","automatedFeeds":false,"cruzidList":"lmnielse, gwenj, milpowel, raknight, jchafin, clagattu","strFacultyTypes":"{\u0022All\u0022:false,\u0022Regular Faculty\u0022:false,\u0022Lecturer\u0022:false,\u0022Emeriti\u0022:false,\u0022Research Professor\u0022:false,\u0022Researcher\u0022:false,\u0022Adjunct Faculty\u0022:false,\u0022Visiting Scholar\u0022:false,\u0022Graduate Student Instructor\u0022:false,\u0022Retired\u0022:false}","strStaffTypes":"{\u0022Regular Staff\u0022:true,\u0022Researcher\u0022:false,\u0022Postdoctoral Scholar\u0022:false}","strGradTypes":"{\u0022Grad Students\u0022:false}","manualAdd":true,"addCruzids":"","excludeCruzids":"","displayDeptartmentAffiliates":false,"linkToProfile":true,"linkOutToCampusDirectory":false,"strInformationTypes":"{\u0022Pronouns\u0022:false,\u0022Photo\u0022:true,\u0022Title\u0022:true,\u0022Department\u0022:false,\u0022Phone\u0022:true,\u0022Campus Email\u0022:true,\u0022Other Email\u0022:false,\u0022Fax\u0022:false,\u0022Website\u0022:false,\u0022Office Location\u0022:false,\u0022Office Hours\u0022:false,\u0022Mailstop\u0022:false,\u0022Mailing Address\u0022:false,\u0022Faculty Areas of Expertise\u0022:false,\u0022Summary of Expertise\u0022:false}","strInformationTypesTable":"{\u0022Pronouns\u0022:false,\u0022Title\u0022:true,\u0022Department\u0022:false,\u0022Phone\u0022:true,\u0022Campus Email\u0022:true,\u0022Other Email\u0022:false,\u0022Fax\u0022:false,\u0022Website\u0022:false,\u0022Office Location\u0022:false,\u0022Office Hours\u0022:false,\u0022Mailstop\u0022:false,\u0022Mailing Address\u0022:false,\u0022Faculty Areas of Expertise\u0022:false,\u0022Summary of Expertise\u0022:false}","department":"Communications \u0026 Marketing","division":"\u002d\u002d-","deptOrDiv":"dept"} /-->
+
+<!-- wp:separator {"backgroundColor":"lightest-gray"} -->
+<hr class="wp-block-separator has-text-color has-lightest-gray-color has-alpha-channel-opacity has-lightest-gray-background-color has-background"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Directions</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"}}},"className":"ucsc-map-contact"} -->
+<div class="wp-block-columns ucsc-map-contact" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"className":"ucsc-map-contact__map"} -->
+<div class="wp-block-column ucsc-map-contact__map"><!-- wp:html -->
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d12746.83386746128!2d-122.0694595657337!3d36.992891465250615!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x808e41a2ff8cbf4f%3A0x3a8e3b7c928320d5!2sUniversity%20of%20California%20Santa%20Cruz!5e0!3m2!1sen!2sus!4v1689093782636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+<!-- /wp:html --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"backgroundColor":"ucsc-primary-yellow","className":"ucsc-map-contact__connect"} -->
+<div class="wp-block-column ucsc-map-contact__connect has-ucsc-primary-yellow-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Main location</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Main office<br>1165 High Street<br>Santa Cruz CA, 95062</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Additional Info</strong><br></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Alternative location</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Contact Info: placeholder</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}},"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-columns has-lightest-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--30)"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"two"} -->
+<h3 class="wp-block-heading has-two-font-size">Subhead to give context to bulleted copy below</h3>
+<!-- /wp:heading -->
+
+<!-- wp:separator {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"light-gray"} -->
+<hr class="wp-block-separator has-text-color has-light-gray-color has-alpha-channel-opacity has-light-gray-background-color has-background" style="margin-top:0;margin-bottom:0"/>
+<!-- /wp:separator -->
+
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Short blurbs that are easy to read and remember</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Consider copy with facts or stats or benefits</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>These are usual memorable facts about your organization</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Your site visitors are most likely to remember items placed here</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->

--- a/patterns/example-page-home.php
+++ b/patterns/example-page-home.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Title: Home Page
+ * Slug: ucsc-2022/home-page
+ * Categories: examples
+ */
+?>
+
+<!-- wp:group {"align":"full","className":"ucsc-page-header","layout":{"type":"default"},"fontSize":"base"} -->
+<div class="wp-block-group alignfull ucsc-page-header has-base-font-size"><!-- wp:cover {"url":"https://sandbox.wordpress.ucsc.edu/files/2023/10/374977842_10160052416824830_6758527851300299566_n.jpg","id":1171,"dimRatio":0,"focalPoint":{"x":0.59,"y":0.53},"minHeight":599,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}},"className":"ucsc-page-header__content"} -->
+<div class="wp-block-cover is-light ucsc-page-header__content" style="padding-top:var(--wp--preset--spacing--50);min-height:599px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-1171" alt="" src="https://sandbox.wordpress.ucsc.edu/files/2023/10/374977842_10160052416824830_6758527851300299566_n.jpg" style="object-position:59% 53%" data-object-fit="cover" data-object-position="59% 53%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"default"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"ucsc-primary-yellow","textColor":"ucsc-primary-blue","className":"ucsc-page-header__title primary-post-title","fontSize":"seven"} /--></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ucsc-secondary-blue","textColor":"white","className":"ucsc__columns-3-with-background-image","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull ucsc__columns-3-with-background-image has-white-color has-ucsc-secondary-blue-background-color has-text-color has-background" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"ucsc-secondary-blue","textColor":"white","className":"ucsc__columns-3-with-background-image","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull ucsc__columns-3-with-background-image has-white-color has-ucsc-secondary-blue-background-color has-text-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:cover {"url":"/wp-content/themes/ucsc-2022/images/endless-clouds.png","id":2007,"isRepeated":true,"dimRatio":0,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover alignfull is-repeated" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40)"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__image-background wp-image-2007 is-repeated" style="background-position:50% 50%;background-image:url(/wp-content/themes/ucsc-2022/images/endless-clouds.png)"></div><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"1280px"}} -->
+<div class="wp-block-group"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"eight"} -->
+<h2 class="wp-block-heading has-text-align-center has-eight-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">#2</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"fontSize":"one"} -->
+<p class="has-text-align-center has-one-font-size" style="font-style:normal;font-weight:500">Description to pair with statistic</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"eight"} -->
+<h2 class="wp-block-heading has-text-align-center has-eight-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">25 </h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"fontSize":"one"} -->
+<p class="has-text-align-center has-one-font-size" style="font-style:normal;font-weight:500">Description to pair with figure</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"eight"} -->
+<h2 class="wp-block-heading has-text-align-center has-eight-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">8</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"className":"is-style-default","fontSize":"one"} -->
+<p class="has-text-align-center is-style-default has-one-font-size" style="font-style:normal;font-weight:500">Description to pair with figure</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"eight"} -->
+<h2 class="wp-block-heading has-text-align-center has-eight-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">10</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"className":"is-style-default","fontSize":"one"} -->
+<p class="has-text-align-center is-style-default has-one-font-size" style="font-style:normal;font-weight:500">Description to pair with figure</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"align":"center","backgroundColor":"ucsc-violator-yellow","className":"is-style-success"} -->
+<p class="has-text-align-center is-style-success has-ucsc-violator-yellow-background-color has-background"><strong>Web editor! Looking for web writing best practices to match this page? </strong><a href="https://websites.ucsc.edu/guides/showcase/pattern-home-page">You can find them here.</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"className":"is-style-ucsc-intro-text"} -->
+<p class="has-text-align-center is-style-ucsc-intro-text" style="margin-top:var(--wp--preset--spacing--30);margin-right:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);margin-left:var(--wp--preset--spacing--30)">High-level overview text that gives your visitor a sense of your vision and goals. Should be brief! </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center","contentSize":"70rem"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:embed {"url":"https://youtu.be/3cSTHIE8yfY?si=DmoOLMUOZcR3g4lS","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://youtu.be/3cSTHIE8yfY?si=DmoOLMUOZcR3g4lS
+</div></figure>
+<!-- /wp:embed -->
+
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"60%"}} -->
+<div class="wp-block-group"><!-- wp:heading {"textColor":"ucsc-primary-blue"} -->
+<h2 class="wp-block-heading has-ucsc-primary-blue-color has-text-color">Compelling subhead</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This text compliments the video story. Have a button after this text ONLY if there is a priority call to action you want your vistor to take. Otherwise you don't need a button.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"ucsc-primary-blue","textColor":"white","className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link has-white-color has-ucsc-primary-blue-background-color has-text-color has-background wp-element-button" href="https://youtube.com/ucsantacruz">Call to action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:separator {"backgroundColor":"light-gray"} -->
+<hr class="wp-block-separator has-text-color has-light-gray-color has-alpha-channel-opacity has-light-gray-background-color has-background"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"className":"ucsc__2-col-card-grid","layout":{"type":"constrained","contentSize":"1280px"}} -->
+<div class="wp-block-group alignfull ucsc__2-col-card-grid" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading -->
+<h2 class="wp-block-heading">Category header</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|20"}}},"className":"ucsc__card-grid"} -->
+<div class="wp-block-columns ucsc__card-grid"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":1375,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/4212020-Spring-Campus-CL-5-1024x683.jpg" alt="Hawk sitting on a fence." class="wp-image-1375"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Subject</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Descriptive copy that will entice the visitor to want to learn more.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":1375,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/4212020-Spring-Campus-CL-5-1024x683.jpg" alt="Hawk sitting on a fence." class="wp-image-1375"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Subject</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Descriptive copy that will entice the visitor to want to learn more.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":1375,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/4212020-Spring-Campus-CL-5-1024x683.jpg" alt="Hawk sitting on a fence." class="wp-image-1375"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Subject</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Descriptive copy that will entice the visitor to want to learn more.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained","contentSize":"200rem"}} -->
+<div class="wp-block-group"><!-- wp:columns {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:column {"layout":{"type":"constrained"}} -->
+<div class="wp-block-column"><!-- wp:media-text {"align":"wide","mediaId":1377,"mediaLink":"https://sandbox.wordpress.ucsc.edu/home/380809459_10160093931984830_1899309074064086171_n/","mediaType":"image","mediaSizeSlug":"thumbnail","verticalAlignment":"top","imageFill":true,"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-top is-image-fill has-lightest-gray-background-color has-background"><figure class="wp-block-media-text__media" style="background-image:url(https://sandbox.wordpress.ucsc.edu/files/2023/10/380809459_10160093931984830_1899309074064086171_n-1024x800.jpg);background-position:50% 50%"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/380809459_10160093931984830_1899309074064086171_n-1024x800.jpg" alt="" class="wp-image-1377 size-thumbnail"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"textColor":"black","fontSize":"xx-large"} -->
+<h2 class="wp-block-heading has-black-color has-text-color has-xx-large-font-size" style="font-style:normal;font-weight:600">Topic subhead </h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"2rem"} -->
+<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>Brief copy written to make people click to learn more. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:column {"layout":{"type":"constrained"}} -->
+<div class="wp-block-column"><!-- wp:media-text {"align":"wide","mediaPosition":"right","mediaId":1403,"mediaLink":"https://sandbox.wordpress.ucsc.edu/home/group-of-watching-surricatas-with-question-marks/","mediaType":"image","mediaSizeSlug":"thumbnail","verticalAlignment":"top","imageFill":true,"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-top is-image-fill has-lightest-gray-background-color has-background"><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"textColor":"black","fontSize":"xx-large"} -->
+<h2 class="wp-block-heading has-black-color has-text-color has-xx-large-font-size" style="font-style:normal;font-weight:600">Topic subhead</h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"2rem"} -->
+<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>Brief copy written to make people click to learn more. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div><figure class="wp-block-media-text__media" style="background-image:url(https://sandbox.wordpress.ucsc.edu/files/2023/10/GettyImages-1141759416.jpg);background-position:50% 50%"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/GettyImages-1141759416.jpg" alt="" class="wp-image-1403 size-thumbnail"/></figure></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"className":"ucsc__2-col-card-grid","layout":{"type":"constrained","contentSize":"1280px"}} -->
+<div class="wp-block-group alignfull ucsc__2-col-card-grid" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading -->
+<h2 class="wp-block-heading">Upcoming events</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|20"}}},"className":"ucsc__card-grid"} -->
+<div class="wp-block-columns ucsc__card-grid"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":1387,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/IMG_5544-edited-1024x683.jpg" alt="turkey next to a car and  looks like it is talking to a person." class="wp-image-1387"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Event title</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Time, date<br>Location<br><br>Inviting description of event.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Link to info or tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":1382,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/redwood-trees-edited-1-1024x682.jpg" alt="Redwood tree" class="wp-image-1382"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Event title</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Time, date<br>Location<br><br>Inviting description of event.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Link to info or tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:separator {"backgroundColor":"light-gray"} -->
+<hr class="wp-block-separator has-text-color has-light-gray-color has-alpha-channel-opacity has-light-gray-background-color has-background"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"lock":{"move":false,"remove":false},"align":"full","backgroundColor":"white","textColor":"black","className":"ucsc__interstitial","layout":{"type":"constrained","contentSize":"1280px","justifyContent":"center"},"fontSize":"two"} -->
+<div class="wp-block-group alignfull ucsc__interstitial has-black-color has-white-background-color has-text-color has-background has-two-font-size"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"ucsc-primary-blue","fontSize":"four"} -->
+<h2 class="wp-block-heading has-text-align-center has-ucsc-primary-blue-color has-text-color has-four-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Subhead that is descriptive or captures attention.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Restate what you want the visitor to do.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="/">Call to action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/patterns/example-page-topic.php
+++ b/patterns/example-page-topic.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Title: Topic Page
+ * Slug: ucsc-2022/topic-page
+ * Categories: examples
+ */
+?>
+
+<!-- wp:group {"align":"full","className":"ucsc-page-header","layout":{"type":"default"},"fontSize":"base"} -->
+<div class="wp-block-group alignfull ucsc-page-header has-base-font-size"><!-- wp:cover {"url":"https://sandbox.wordpress.ucsc.edu/files/2024/06/11182020-Coyote-Fog-CL-001-2.jpg","id":1970,"dimRatio":0,"minHeight":510,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}},"className":"ucsc-page-header__content"} -->
+<div class="wp-block-cover is-light ucsc-page-header__content" style="padding-top:var(--wp--preset--spacing--50);min-height:510px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-1970" alt="" src="https://sandbox.wordpress.ucsc.edu/files/2024/06/11182020-Coyote-Fog-CL-001-2.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"default"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"textAlign":"right","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"ucsc-primary-yellow","textColor":"ucsc-primary-blue","className":"ucsc-page-header__title primary-post-title","fontSize":"seven"} /--></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"align":"center","backgroundColor":"ucsc-violator-yellow","className":"is-style-success"} -->
+<p class="has-text-align-center is-style-success has-ucsc-violator-yellow-background-color has-background"><strong>Web editor! Looking for web writing best practices to match this page? </strong><a href="https://websites.ucsc.edu/guides/showcase/pattern-landing-page">You can find them here.</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"align":"center","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|40","top":"var:preset|spacing|20"}}},"className":"is-style-ucsc-intro-text"} -->
+<p class="has-text-align-center is-style-ucsc-intro-text" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)">Describe your program here in a sentence or two, giving visitors basic information to make them feel grounded. Use simple language and be honest and genuine, while enticing visitors to want to learn more.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"light-gray"} -->
+<hr class="wp-block-separator alignfull has-text-color has-light-gray-color has-alpha-channel-opacity has-light-gray-background-color has-background" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Research news</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1975,"aspectRatio":"16/9","scale":"cover","sizeSlug":"full","linkDestination":"custom"} -->
+<figure class="wp-block-image size-full"><img src="https://sandbox.wordpress.ucsc.edu/files/2024/06/fort-ord-reserve-main.jpeg" alt="Fort Ord Natural Reserve Director Joe Miller introducing field studies to students from a nearby charter high school. (Photo by Barbara Lawrence-Emanuel, Learning for Life Charter School)" class="wp-image-1975" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium"} -->
+<h2 class="wp-block-heading has-medium-font-size" style="margin-bottom:0;line-height:1.4">Short headline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+<p style="margin-top:var(--wp--preset--spacing--20)">Short, descriptive blurb of about 35–40 words that enables quick skimming.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1978,"aspectRatio":"16/9","scale":"cover","sizeSlug":"full","linkDestination":"custom"} -->
+<figure class="wp-block-image size-full"><img src="https://sandbox.wordpress.ucsc.edu/files/2024/06/sea-otters-tools-lead.jpg" alt="UC Santa Cruz researchers used biomechanical and functional morphology to measure how hard sea otters need to bite to break open prey of various sizes. (Photo by Jessica Fujii, Monterey Bay Aquarium)" class="wp-image-1978" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"style":{"typography":{"lineHeight":"1.4"}},"fontSize":"medium"} -->
+<h2 class="wp-block-heading has-medium-font-size" style="line-height:1.4">Short headline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+<p style="margin-top:var(--wp--preset--spacing--20)">Short, descriptive blurb of about 35–40 words that enables quick skimming.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1981,"aspectRatio":"16/9","scale":"cover","sizeSlug":"full","linkDestination":"custom"} -->
+<figure class="wp-block-image size-full"><img src="https://sandbox.wordpress.ucsc.edu/files/2024/06/pinsky-larkin-lead.jpg" alt="Malin Pinsky (Photo by Nick Romanenko)" class="wp-image-1981" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium"} -->
+<h2 class="wp-block-heading has-medium-font-size" style="margin-bottom:0;line-height:1.4">Short headline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+<p style="margin-top:var(--wp--preset--spacing--20)">Short, descriptive blurb of about 35–40 words that enables quick skimming.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:cover {"overlayColor":"ucsc-secondary-blue","isUserOverlayColor":true,"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover alignfull" style="margin-top:var(--wp--preset--spacing--40)"><span aria-hidden="true" class="wp-block-cover__background has-ucsc-secondary-blue-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"layout":{"type":"constrained","contentSize":"1080px"}} -->
+<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"textAlign":"left","level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"0","bottom":"0","left":"0"}}}} -->
+<h3 class="wp-block-heading has-text-align-left" style="padding-top:var(--wp--preset--spacing--20);padding-right:0;padding-bottom:0;padding-left:0">Engaging subhead</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"one"} -->
+<p class="has-one-font-size">Short, descriptive blurb of about 35–40 words that enables quick skimming.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"textColor":"ucsc-primary-blue","className":"is-style-ucsc-gold"} -->
+<div class="wp-block-button is-style-ucsc-gold"><a class="wp-block-button__link has-ucsc-primary-blue-color has-text-color wp-element-button">Call to action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1986,"width":"640px","aspectRatio":"1.5050167224080269","sizeSlug":"large","linkDestination":"none","align":"center"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://sandbox.wordpress.ucsc.edu/files/2024/06/AK7A4722-1024x683.jpg" alt="Images of Big Creek Reserve—taken by UCOP photographer, Lobsang Wangdu (lobsang.wangdu@ucop.edu)" class="wp-image-1986" style="aspect-ratio:1.5050167224080269;width:640px"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:heading {"textAlign":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+<h2 class="wp-block-heading has-text-align-center" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">Engaging subhead</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=kVDQiF9dMlE","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=kVDQiF9dMlE
+</div></figure>
+<!-- /wp:embed --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=CRqmmgqMquo","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=CRqmmgqMquo
+</div></figure>
+<!-- /wp:embed --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=cI-_F2lfcwI\u0026t=68s","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=cI-_F2lfcwI&amp;t=68s
+</div></figure>
+<!-- /wp:embed --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":"31px"} -->
+<div style="height:31px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"type":"constrained","contentSize":"200rem"}} -->
+<div class="wp-block-group"><!-- wp:columns {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:column {"layout":{"type":"constrained"}} -->
+<div class="wp-block-column"><!-- wp:media-text {"align":"wide","mediaId":1377,"mediaLink":"https://sandbox.wordpress.ucsc.edu/home/380809459_10160093931984830_1899309074064086171_n/","mediaType":"image","mediaSizeSlug":"thumbnail","verticalAlignment":"top","imageFill":true,"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-top is-image-fill has-lightest-gray-background-color has-background"><figure class="wp-block-media-text__media" style="background-image:url(https://sandbox.wordpress.ucsc.edu/files/2023/10/380809459_10160093931984830_1899309074064086171_n-1024x800.jpg);background-position:50% 50%"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/380809459_10160093931984830_1899309074064086171_n-1024x800.jpg" alt="" class="wp-image-1377 size-thumbnail"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"textColor":"black","fontSize":"xx-large"} -->
+<h2 class="wp-block-heading has-black-color has-text-color has-xx-large-font-size" style="font-style:normal;font-weight:600">Topic subhead </h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"2rem"} -->
+<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>Brief copy written to make people click to learn more. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:column {"layout":{"type":"constrained"}} -->
+<div class="wp-block-column"><!-- wp:media-text {"align":"wide","mediaPosition":"right","mediaId":1403,"mediaLink":"https://sandbox.wordpress.ucsc.edu/home/group-of-watching-surricatas-with-question-marks/","mediaType":"image","mediaSizeSlug":"thumbnail","verticalAlignment":"top","imageFill":true,"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-top is-image-fill has-lightest-gray-background-color has-background"><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"textColor":"black","fontSize":"xx-large"} -->
+<h2 class="wp-block-heading has-black-color has-text-color has-xx-large-font-size" style="font-style:normal;font-weight:600">Topic subhead</h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"2rem"} -->
+<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>Brief copy written to make people click to learn more. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div><figure class="wp-block-media-text__media" style="background-image:url(https://sandbox.wordpress.ucsc.edu/files/2023/10/GettyImages-1141759416.jpg);background-position:50% 50%"><img src="https://sandbox.wordpress.ucsc.edu/files/2023/10/GettyImages-1141759416.jpg" alt="" class="wp-image-1403 size-thumbnail"/></figure></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"lock":{"move":false,"remove":false},"align":"full","backgroundColor":"white","textColor":"black","className":"ucsc__interstitial","layout":{"type":"constrained","contentSize":"1280px","justifyContent":"center"},"fontSize":"two"} -->
+<div class="wp-block-group alignfull ucsc__interstitial has-black-color has-white-background-color has-text-color has-background has-two-font-size"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"ucsc-primary-blue","fontSize":"four"} -->
+<h2 class="wp-block-heading has-text-align-center has-ucsc-primary-blue-color has-text-color has-four-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Subhead that is descriptive or captures attention.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Restate what you want the visitor to do.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="/">Call to action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","backgroundColor":"ucsc-primary-yellow","layout":{"inherit":false}} -->
+<div class="wp-block-column is-vertically-aligned-center has-ucsc-primary-yellow-background-color has-background"><!-- wp:media-text {"align":"wide","mediaPosition":"right","mediaId":1992,"mediaLink":"https://sandbox.wordpress.ucsc.edu/research/20210718-235745/","mediaType":"image","mediaSizeSlug":"thumbnail","verticalAlignment":"top","imageFill":true,"backgroundColor":"lightest-gray"} -->
+<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-top is-image-fill has-lightest-gray-background-color has-background"><div class="wp-block-media-text__content"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1.1"}},"textColor":"black","fontSize":"four"} -->
+<h2 class="wp-block-heading has-black-color has-text-color has-four-font-size" style="font-style:normal;font-weight:400;line-height:1.1"><br><strong>Subhead about program or projects</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Short, descriptive blurb of about 35–40 words that enables quick skimming.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call to action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div><figure class="wp-block-media-text__media" style="background-image:url(https://sandbox.wordpress.ucsc.edu/files/2024/06/20210718-235745-1024x683.jpg);background-position:50% 50%"><img src="https://sandbox.wordpress.ucsc.edu/files/2024/06/20210718-235745-1024x683.jpg" alt="" class="wp-image-1992 size-thumbnail"/></figure></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase"},"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}}},"fontSize":"medium"} -->
+<h2 class="wp-block-heading has-text-align-left has-medium-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20);text-transform:uppercase"><strong>additional information:</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"ucsc-primary-blue"} -->
+<p class="has-ucsc-primary-blue-color has-text-color" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><a href="https://officeofresearch.ucsc.edu/index.html">Office of Research</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph {"textColor":"ucsc-primary-blue"} -->
+<p class="has-ucsc-primary-blue-color has-text-color"><a href="https://siliconvalley.ucsc.edu/">Silicon Valley Campus</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph {"textColor":"ucsc-primary-blue"} -->
+<p class="has-ucsc-primary-blue-color has-text-color"><a href="https://science.ucsc.edu/groups-facilities/coastal-science-campus/">Coastal Science Campus</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
## What does this do/fix?
This PR creates a new pattern category called ***Examples*** and adds three full-page examples to the theme pattern library: ***Home Page***, ***About Page*** and ***Topic Page***.

These patterns are best used with the ***Page No Title*** page template.

_**Note:**_ as discussed previously, the images in these patterns are being pulled from the [Wildlife Division](https://sandbox.wordpress.ucsc.edu/) Sandbox site, which served as a template for these patterns.

## QA

Links to relevant issues
Closes #350 

Screenshots/video:

![ucsc-theme-editor-patterns](https://github.com/user-attachments/assets/b27f37d0-862c-4ec2-a7b9-28cf233cfb95)
_New Examples category and patterns in the Theme Editor_

![ucsc-page-editor-patterns](https://github.com/user-attachments/assets/a9c4c367-cab8-4306-ba12-6eb925fb169e)
_New Examples category and patterns in the Page Editor_


https://github.com/user-attachments/assets/0f89ed6d-7c43-42e3-bbc1-190fbeef25f3
_Demo video_

## Tests

Test by checking out this PR locally and compare screenshots and demo to experience in Local Dev Environment.
