### PR TITLE
fix(css): 🚑️ Properly scope the styles that set `body` and `html` at 100% height to front-end only

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,21 @@
+{
+	"extends": "@wordpress/stylelint-config",
+	"rules": {
+		"at-rule-no-unknown": [
+			true,
+			{
+				"ignoreAtRules": [
+					"view-transition"
+				]
+			}
+		],
+		"property-no-unknown": [
+			true,
+			{
+				"ignoreProperties": [
+					"navigation"
+				]
+			}
+		]
+	}
+}

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -1,6 +1,7 @@
-html,
-body {
-	height: 100%;
+html:not(.wp-toolbar),
+body.wp-theme-ucsc-2022 {
+	min-height: 100dvh;
+	height: auto;
 }
 
 body {

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -4,7 +4,7 @@ body.wp-theme-ucsc-2022 {
 	height: auto;
 }
 
-body {
+body.wp-theme-ucsc-2022 {
 	display: flex;
 	flex-direction: column;
 }

--- a/style.css
+++ b/style.css
@@ -1,18 +1,18 @@
 /*
-Theme Name: UCSC 2022
-Theme URI: http://github.com/ucsc/ucsc-2022
-Author: UC Santa Cruz
-Author URI: https://www.ucsc.edu
-Description: The official WordPress theme for UC Santa Cruz
-Tags: full-site-editing, blog
-Version: 4.3.2
-Requires at least: 6.0
-Tested up to: 6.4.2
-Requires PHP: 7.0
-License: GNU General Public License v2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: ucsc-2022
-GitHub Theme URI: http://github.com/ucsc/ucsc-2022
+Theme Name:					UCSC 2022
+Theme URI: 					http://github.com/ucsc/ucsc-2022
+Author: 						UC Santa Cruz
+Author URI: 				https://www.ucsc.edu
+Description: 				The official WordPress theme for UC Santa Cruz
+Tags: 							full-site-editing, blog
+Version: 						4.3.2
+Requires at least: 	6.0
+Tested up to: 			6.9.4
+Requires PHP: 			7.4
+License: 						GNU General Public License v2 or later
+License URI: 				http://www.gnu.org/licenses/gpl-2.0.html
+Update URI: 				http://github.com/ucsc/ucsc-2022/releases
+Text Domain: 				ucsc-2022
 */
 
 body * {
@@ -20,7 +20,9 @@ body * {
 }
 
 @media (prefers-reduced-motion: no-preference) {
+
 	@view-transition {
 		navigation: auto;
 	}
+
 }


### PR DESCRIPTION
Fixes #391

Resolves an issue where the iframe containing the TinyMCE editor had styles in conflict with a WordPress core script that automatically resizes it to fit the content inside of it.

In `base/layout`, the `height: 100%;` rule on html and body caused the issue.

This change scopes those rules to only the front-end body and html tags.

## Tests

With this change in place, add or edit an event. The text box for the description should initially resize, then stop. It should not resize based on any events that happen outside of it.