### PR TITLE
block(core/cover): Add accessibility controls to background videos

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -35,6 +35,7 @@ if (!function_exists('ucsc_setup')):
 		$styled_blocks = [
 			'core/button',
 			'core/columns',
+			'core/cover',
 			'core/post-template',
 			'core/post-author',
 			'core/site-title',
@@ -190,6 +191,13 @@ function ucsc_scripts()
 		true
 	);
 	wp_enqueue_script('ucsc-front');
+	wp_enqueue_script(
+		'cover-block-video-controls',
+		get_theme_file_uri('lib/cover-block-video-controls.js'),
+		[],
+		wp_get_theme()->get('Version'),
+		['strategy' => 'defer']
+	);
 }
 add_action('wp_enqueue_scripts', 'ucsc_scripts');
 
@@ -319,6 +327,41 @@ function ucsc_post_subtitle($block_content = '', $block = [])
 	}
 	return $block_content;
 }
+
+add_filter('render_block_core/cover', function ($block_content, $block) {
+	if (empty($block['attrs']['backgroundType']) || $block['attrs']['backgroundType'] !== 'video') {
+		return $block_content;
+	}
+	if (empty($block['attrs']['url'])) {
+		return $block_content;
+	}
+
+	// Normalize to the scheme of the current request so the emitted URL
+	// isn't blocked as mixed content when the page is served over https.
+	$video_url = set_url_scheme($block['attrs']['url']);
+	$vtt_url   = preg_replace('/\.(mp4|webm|mov|m4v)$/i', '.vtt', $video_url);
+
+	// Resolve to a local filesystem path independent of http/https. The
+	// stored block URL and site_url() can disagree on scheme (e.g. on a
+	// Local site reachable over both), which would break a plain
+	// str_replace() and skip the track over https.
+	$relative = wp_make_link_relative($vtt_url);
+	$vtt_path = wp_normalize_path(ABSPATH . ltrim($relative, '/'));
+	if (! file_exists($vtt_path)) {
+		return $block_content;
+	}
+
+	$track = sprintf(
+		'<track kind="captions" src="%s" srclang="en" label="English" default>',
+		esc_url($vtt_url)
+	);
+
+	// Inject the <track> just before </video>
+	return preg_replace('#</video>#', $track . '</video>', $block_content, 1);
+}, 10, 2);
+
+
+
 add_filter('render_block', 'ucsc_post_subtitle', 10, 2);
 
 /**

--- a/lib/cover-block-video-controls.js
+++ b/lib/cover-block-video-controls.js
@@ -1,0 +1,81 @@
+(function () {
+	function buildControls(video, cover) {
+		// Video plays and loops by default; autoplay is disabled below when
+		// the user prefers reduced motion.
+
+		// Both icons share the same 24x24 viewBox so they render at an
+		// identical height; only the path differs.
+		const ICON_PAUSE =
+			'<svg class="cv-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M7 5h3v14H7zM14 5h3v14h-3z"/></svg>';
+		const ICON_PLAY =
+			'<svg class="cv-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8 5v14l11-7z"/></svg>';
+
+		const bar = document.createElement('div');
+		bar.className = 'cv-controls';
+		bar.innerHTML = `
+    <button class="cv-btn cv-play" aria-label="Pause">${ICON_PAUSE}<span class="cv-label">Pause</span></button>
+    <button class="cv-btn cv-cc"   aria-label="Turn captions on" aria-pressed="false">Captions</button>
+  `;
+		cover.insertAdjacentElement('afterend', bar);
+
+		const playBtn = bar.querySelector('.cv-play');
+		const ccBtn = bar.querySelector('.cv-cc');
+
+		// Play / pause — sync button to actual video state
+		const playLabel = playBtn.querySelector('.cv-label');
+		const syncPlayBtn = () => {
+			const playing = !video.paused;
+			playBtn.querySelector('.cv-icon').outerHTML = playing
+				? ICON_PAUSE
+				: ICON_PLAY;
+			playLabel.textContent = playing ? 'Pause' : 'Play';
+			playBtn.setAttribute('aria-label', playing ? 'Pause' : 'Play');
+		};
+		syncPlayBtn();
+
+		playBtn.addEventListener('click', () => {
+			video.paused ? video.play() : video.pause();
+		});
+		video.addEventListener('play', syncPlayBtn);
+		video.addEventListener('pause', syncPlayBtn);
+
+		// Respect prefers-reduced-motion: don't autoplay the background video.
+		// Strip the autoplay attribute so it can't restart, and pause anything
+		// the browser already began. The user can still start it manually.
+		const reduceMotion = window.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		);
+		const applyReducedMotion = () => {
+			if (reduceMotion.matches) {
+				video.removeAttribute('autoplay');
+				video.pause();
+			}
+		};
+		applyReducedMotion();
+		reduceMotion.addEventListener('change', applyReducedMotion);
+
+		// Captions
+		const track = video.textTracks && video.textTracks[0];
+		if (!track) {
+			ccBtn.hidden = true;
+			return;
+		}
+		track.mode = 'hidden';
+
+		ccBtn.addEventListener('click', () => {
+			const on = track.mode === 'showing';
+			track.mode = on ? 'hidden' : 'showing';
+			ccBtn.setAttribute('aria-pressed', String(!on));
+			ccBtn.setAttribute(
+				'aria-label',
+				on ? 'Turn captions on' : 'Turn captions off'
+			);
+			ccBtn.classList.toggle('is-on', !on);
+		});
+	}
+
+	document.querySelectorAll('.wp-block-cover').forEach((cover) => {
+		const video = cover.querySelector('.wp-block-cover__video-background');
+		if (video) buildControls(video, cover);
+	});
+})();

--- a/wp-blocks/cover.css
+++ b/wp-blocks/cover.css
@@ -1,0 +1,72 @@
+.cv-controls {
+	background: var(--wp--preset--color--ucsc-secondary-blue);
+	display: flex;
+	justify-content: center;
+	margin: 0 auto;
+	width: fit-content;
+
+	/* The inset is the horizontal distance from the edge to the point where the
+	   curve's tangent is horizontal. It controls how "deep" the curve is, and
+	   thus how far the shoulders extend out from the body. */
+	--tab-inset: 4rem;
+	padding: 0.35em var(--tab-inset);
+
+	/* Straight-sided fallback for browsers without shape() support. */
+	clip-path: polygon(0 0, 100% 0, calc(100% - var(--tab-inset)) 100%, var(--tab-inset) 100%);
+
+	/* Smooth S-curved sides. Each curve's control points sit at half the
+	   inset with a horizontal tangent at both the top and bottom, so the
+	   shoulders are evenly rounded and the curve is symmetric. */
+	clip-path: shape(from 0 0, curve to var(--tab-inset) 100% with calc(var(--tab-inset) / 2) 0 / calc(var(--tab-inset) / 2) 100%, line to calc(100% - var(--tab-inset)) 100%, curve to 100% 0 with calc(100% - var(--tab-inset) / 2) 100% / calc(100% - var(--tab-inset) / 2) 0, close);
+}
+
+.wp-block-cover + .cv-controls {
+	margin-block-start: 0;
+	backdrop-filter: blur(10px);
+}
+
+.cv-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	color: #fff;
+	border: 0;
+	padding: 0.6em 1em;
+	font-size: 1rem;
+	line-height: 1;
+	cursor: pointer;
+	border-radius: 4px;
+	transition: background-color 0.25s;
+	min-width: 8em;
+	margin: 0 0.2em;
+	gap: 0.4em;
+
+	&:hover,
+	&:active {
+		background: var(--wp--preset--color--ucsc-primary-blue);
+	}
+
+	&:focus-visible {
+		outline: 2px solid #a3ffa4;
+		outline-offset: -2px;
+	}
+
+}
+
+/* Fixed-size SVG icons. Both share a 24x24 viewBox, so equal width/height
+   here guarantees the play and pause icons render at the same size and the
+   button doesn't shift when toggling. */
+.cv-icon {
+	flex: none;
+	width: 1.2em;
+	height: 1.2em;
+	display: block;
+}
+
+/* Active state for the captions button. The .is-on class is added via
+	 JavaScript when the toggle is active. */
+.cv-cc.is-on {
+	background: var(--wp--preset--color--ucsc-green);
+	color: #000;
+}


### PR DESCRIPTION
Fixes #397

This commit adds controls to a video background in the cover block. Play/pause is added to the bottom of the player. If an identically-named captions file exists in the media library, a captions button is added to the controls. The video player respects `prefers-reduced-motion` and stops playback when the setting is `reduce`.

Users will need to be mindful to not place text boxes within the cover block if captions are available.

## Testing

1. Add a cover block to a page, and add a video background to the cover block. Expect a play/pause button to appear under the video when you load the page.
2. Add a proper captions file with the _exact same name_ as the video file (case sensitive, with a `.vtt` extension) to your media library. Expect to see a "Captions" toggle button along side the play/pause control when you load the page. 
3. Use an image in the cover block instead of a video. Expect to see just the image, no controls should be present.

<img width="1540" height="1262" alt="171522-2026-06-18" src="https://github.com/user-attachments/assets/6efcaa13-54b1-4ec0-a2a6-f3b281dd8485" />
