### PR TITLE
templates: Fix template files with broken JSON. Fixes #399

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -1,1 +1,1 @@
-<!-- wp:template-part {"slug":"site-header",className":"site-header"} /-->
+<!-- wp:template-part {"slug":"site-header","className":"site-header"} /-->

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header",tagName":"header","className":"header-region"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"header-region"} /-->
 <!-- wp:template-part {"slug":"breadcrumbs","tagName":"section","className":"breadcrumbs-region"} /-->
 
 <!-- wp:group {"tagName":"main","className":"content-region","layout":{"inherit":true}} -->
@@ -27,4 +27,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer",tagName":"footer","className":"footer-region"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"footer-region"} /-->

--- a/templates/page-no-title-with-breadcrumbs.html
+++ b/templates/page-no-title-with-breadcrumbs.html
@@ -1,5 +1,5 @@
-<!-- wp:template-part {"slug":"header",tagName":"header","className":"header-region"} /-->
-<!-- wp:template-part {"slug":"breadcrumbs",tagName":"section","className":"breadcrumbs-region"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"header-region"} /-->
+<!-- wp:template-part {"slug":"breadcrumbs","tagName":"section","className":"breadcrumbs-region"} /-->
 
 <!-- wp:group {"tagName":"main", "className":"content-region"} -->
 <main class="wp-block-group content-region">
@@ -9,4 +9,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer",tagName":"footer","className":"footer-region"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"footer-region"} /-->


### PR DESCRIPTION
## What does this do/fix?

Fixes a regression I created in the last release. I removed the `theme` JSON key from the template files. However, I left out a double quote and the JSON left behind was broken. That caused header content to be missing when the theme was updated on sites. This fixes that regression. 

## Tests

1. Update the theme to this version.
2. Reset the header template part. 
3. It should appear as expected (minus any site-level customizations you previously made, which are removed when you reset the part.)