### PR TITLE
fix: Main menu scrolls properly on small screens. Fixes #393

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -171,11 +171,14 @@ function ucsc_scripts()
 		[],
 		wp_get_theme()->get('Version')
 	);
+	$ucsc_css_path = get_theme_file_path('build/style-index.css');
 	wp_enqueue_style(
 		'ucsc-styles-scss',
 		get_template_directory_uri() . '/build/style-index.css',
 		[],
-		wp_get_theme()->get('Version')
+		// Version on file contents, not the theme version — otherwise rebuilt
+		// assets are served from stale browser caches until the next release.
+		file_exists($ucsc_css_path) ? (string) filemtime($ucsc_css_path) : wp_get_theme()->get('Version')
 	);
 	wp_enqueue_style(
 		'ucsc-google-roboto-font',
@@ -183,11 +186,14 @@ function ucsc_scripts()
 		false
 	);
 	wp_enqueue_style('dashicons');
+	$ucsc_theme_asset = file_exists(get_theme_file_path('build/theme.asset.php'))
+		? include get_theme_file_path('build/theme.asset.php')
+		: ['dependencies' => [], 'version' => wp_get_theme()->get('Version')];
 	wp_register_script(
 		'ucsc-front',
 		get_template_directory_uri() . '/build/theme.js',
-		[],
-		wp_get_theme()->get('Version'),
+		$ucsc_theme_asset['dependencies'],
+		$ucsc_theme_asset['version'],
 		true
 	);
 	wp_enqueue_script('ucsc-front');

--- a/src/js/components/main-nav.js
+++ b/src/js/components/main-nav.js
@@ -8,6 +8,9 @@ import state from '../config/state';
 import { NAVIGATION_BREAKPOINT } from '../config/options';
 import * as bodyLock from '../utils/body-lock';
 
+// Matches the 0.2s height transition on .site-header__navigation, plus slack.
+const ANIMATION_CLEANUP_MS = 300;
+
 // Cache some elements and state.
 const cache = {
 	desktopBreakpoint: NAVIGATION_BREAKPOINT,
@@ -18,25 +21,95 @@ const cache = {
 	navIsOpen: false,
 	navToggle: null,
 	menuItems: [],
+	animationTimer: null,
+};
+
+/**
+ * Remove the transient animation-state classes.
+ */
+const clearAnimationClasses = () => {
+	window.clearTimeout(cache.animationTimer);
+	document.documentElement.classList.remove(
+		'main-nav--is-opening',
+		'main-nav--is-closing'
+	);
+};
+
+/**
+ * Guarantee the animation-state classes are cleared even when the height
+ * transition never runs (invalid height calc) or is interrupted (rapid
+ * toggling) — in both cases no transitionend fires. Correctness must never
+ * depend on transition events.
+ */
+const scheduleAnimationCleanup = () => {
+	window.clearTimeout(cache.animationTimer);
+	cache.animationTimer = window.setTimeout(
+		clearAnimationClasses,
+		ANIMATION_CLEANUP_MS
+	);
+};
+
+/**
+ * Publish the site header's current height for the menu's height calc.
+ * Null-guarded: the .site-header class comes from template-part block
+ * attributes and is not guaranteed to exist in the rendered markup.
+ */
+const measureSiteHeader = () => {
+	const siteHeader = document.querySelector('.site-header');
+	if (siteHeader) {
+		document.documentElement.style.setProperty(
+			'--site-header-height',
+			siteHeader.clientHeight + 'px'
+		);
+	}
+};
+
+/**
+ * Anchor the open panel to the sticky header's real bottom edge in viewport
+ * coordinates. The panel is position: fixed, so this stays correct whether
+ * the Truss header above is expanded, missing, or replaced by a banner —
+ * the theme cannot rely on collapsing the Truss header (its internals are
+ * shadow-DOM encapsulated, so theme selectors can't reach it).
+ */
+const measurePanelTop = () => {
+	const anchor = cache.stickyHeader || document.querySelector('.site-header');
+	if (anchor) {
+		document.documentElement.style.setProperty(
+			'--nav-panel-top',
+			Math.max(0, anchor.getBoundingClientRect().bottom) + 'px'
+		);
+	}
 };
 
 /**
  * Show the main-nav menu on mobile.
  */
 const showMenu = () => {
+	// Re-measure the header at the moment we open. The load-time measurement
+	// goes stale once fonts and the async Truss header settle, and a
+	// too-small value makes the panel extend past the viewport bottom with
+	// its tail unreachable.
+	measureSiteHeader();
+	measurePanelTop();
+
 	// Stop observing the sticky header when we open the menu, because it's going
 	// to float to the top of the viewport and not reflect our actual scroll
-	// position.
-	cache.stickyHeaderObserver.unobserve( cache.stickyHeader );
+	// position. Clear its class too: the observer can't update it while the
+	// menu is open, and a stale "stuck" state overrides the collapsed Truss
+	// header in CSS.
+	cache.stickyHeaderObserver.unobserve(cache.stickyHeader);
+	document.documentElement.classList.remove('header-region--stuck');
 	bodyLock.lock();
 
-	document.documentElement.classList.add( 'main-nav--is-open' );
-	if ( ! cache.navIsOpen ) {
-		document.documentElement.classList.add( 'main-nav--is-opening' );
+	document.documentElement.classList.remove('main-nav--is-closing');
+	document.documentElement.classList.add('main-nav--is-open');
+	if (!cache.navIsOpen) {
+		document.documentElement.classList.add('main-nav--is-opening');
 	}
+	scheduleAnimationCleanup();
 
-	cache.nav.setAttribute( 'aria-hidden', false );
-	cache.navToggle.setAttribute( 'aria-label', 'Hide main navigation menu' );
+	cache.nav.setAttribute('aria-hidden', false);
+	cache.navToggle.setAttribute('aria-label', 'Hide main navigation menu');
 	cache.navIsOpen = true;
 };
 
@@ -44,28 +117,33 @@ const showMenu = () => {
  * Hide the main-nav menu on mobile.
  */
 const hideMenu = () => {
-	document.documentElement.classList.remove( 'main-nav--is-open' );
-	if ( cache.navIsOpen ) {
-		document.documentElement.classList.add( 'main-nav--is-closing' );
+	document.documentElement.classList.remove(
+		'main-nav--is-open',
+		'main-nav--is-opening'
+	);
+	if (cache.navIsOpen) {
+		document.documentElement.classList.add('main-nav--is-closing');
 	}
+	scheduleAnimationCleanup();
 
-	cache.nav.setAttribute( 'aria-hidden', true );
-	cache.navToggle.setAttribute( 'aria-label', 'Show main navigation menu' );
+	cache.nav.setAttribute('aria-hidden', true);
+	cache.navToggle.setAttribute('aria-label', 'Show main navigation menu');
 
 	// Reset submenus when the main nav is hidden.
-	cache.menuItems.forEach( ( data ) => {
-		deactivateMenuItem( data );
-	} );
+	cache.menuItems.forEach((data) => {
+		deactivateMenuItem(data);
+	});
 
-	// If we unlock the body before our closing animation completes, the scroll
-	// position will be off in some cases. For that reason, we unlock the body in
-	// our transitionended event handler. However, if the nav is already hidden,
-	// no transition will occur, so we handle that here.
-	if ( ! cache.navIsOpen && bodyLock.isLocked() ) {
+	// Unlock the body immediately. Deferring this to the closing transition's
+	// end left the page frozen whenever that transition never ran or was
+	// interrupted (no transitionend fires in either case).
+	if (bodyLock.isLocked()) {
 		bodyLock.unlock();
 	}
 
-	cache.stickyHeaderObserver.observe( cache.stickyHeader );
+	// Re-observe only after the body is unlocked so the observer measures
+	// real scroll geometry.
+	cache.stickyHeaderObserver.observe(cache.stickyHeader);
 	cache.navIsOpen = false;
 };
 
@@ -73,7 +151,7 @@ const hideMenu = () => {
  * Toggle the main-nav menu on mobile.
  */
 const toggleMenu = () => {
-	if ( cache.navIsOpen ) {
+	if (cache.navIsOpen) {
 		hideMenu();
 	} else {
 		showMenu();
@@ -84,18 +162,18 @@ const toggleMenu = () => {
  * Add JS behaviors to the main-nav menu.
  */
 const initMainNav = () => {
-	cache.nav = document.querySelector( '[data-js="main-nav"]' );
-	if ( ! cache.nav ) {
+	cache.nav = document.querySelector('[data-js="main-nav"]');
+	if (!cache.nav) {
 		return;
 	}
 
 	// Observer when our sticky header becomes "stuck".
-	cache.stickyHeader = document.querySelector( '.header-region' );
+	cache.stickyHeader = document.querySelector('.header-region');
 	cache.stickyHeaderObserver = new window.IntersectionObserver(
-		( entries ) => {
+		(entries) => {
 			document.documentElement.classList.toggle(
 				'header-region--stuck',
-				entries[ 0 ].intersectionRatio < 1
+				entries[0].intersectionRatio < 1
 			);
 		},
 		{
@@ -106,91 +184,82 @@ const initMainNav = () => {
 
 	// Get our mobile-to-desktop breakpoint.
 	const breakpoint = window
-		.getComputedStyle( cache.nav )
-		.getPropertyValue( '--desktop-breakpoint' )
-		.replace( 'px', '' );
-	if ( breakpoint ) {
-		cache.desktopBreakpoint = parseInt( breakpoint );
+		.getComputedStyle(cache.nav)
+		.getPropertyValue('--desktop-breakpoint')
+		.replace('px', '');
+	if (breakpoint) {
+		cache.desktopBreakpoint = parseInt(breakpoint);
 	}
 
-	// Update CSS classes for navigation animation states.
-	const navigation = document.querySelector( '.site-header__navigation' );
-	navigation.addEventListener( 'transitionend', () => {
-		document.documentElement.classList.remove(
-			'main-nav--is-opening',
-			'main-nav--is-closing'
-		);
-		// Unlock the body after the nav is closed.
-		if ( ! cache.navIsOpen && bodyLock.isLocked() ) {
-			bodyLock.unlock();
+	// Clear the animation-state classes when the menu's own height transition
+	// settles. These classes are cosmetic; the timer in show/hideMenu backstops
+	// this cleanup, so correctness never depends on these events firing. The
+	// guards matter: transitions on descendants (submenu wrappers, link
+	// hovers) bubble up to this element.
+	const onTransitionSettled = (event) => {
+		if (
+			event.target !== event.currentTarget ||
+			event.propertyName !== 'height'
+		) {
+			return;
 		}
-	} );
+		clearAnimationClasses();
+	};
+	cache.nav.addEventListener('transitionend', onTransitionSettled);
+	cache.nav.addEventListener('transitioncancel', onTransitionSettled);
 
 	// Add mobile nav toggle.
-	cache.navToggle = document.querySelector(
-		'.site-header__navigation-toggle'
-	);
-	cache.navToggle.addEventListener( 'click', toggleMenu );
+	cache.navToggle = document.querySelector('.site-header__navigation-toggle');
+	cache.navToggle.addEventListener('click', toggleMenu);
 
 	// Add menu item behaviors.
-	cache.nav
-		.querySelectorAll( '.menu > .menu-item' )
-		.forEach( ( menuItem ) => {
-			// Cache menu item data, including references to the different elements
-			// connected to this menu item.
-			const data = {
-				menuItem,
-				submenu: null,
-				toggle: null,
-				links: null,
-				isActive: false,
-			};
-			cache.menuItems.push( data );
+	cache.nav.querySelectorAll('.menu > .menu-item').forEach((menuItem) => {
+		// Cache menu item data, including references to the different elements
+		// connected to this menu item.
+		const data = {
+			menuItem,
+			submenu: null,
+			toggle: null,
+			links: null,
+			isActive: false,
+		};
+		cache.menuItems.push(data);
 
-			// Listen for mouse and keyboard interactions.
-			data.menuItem.addEventListener( 'focusin', () =>
-				updateMenuItem( data )
-			);
-			data.menuItem.addEventListener( 'focusout', () =>
-				updateMenuItem( data )
-			);
-			data.menuItem.addEventListener( 'mouseover', () =>
-				updateMenuItem( data )
-			);
-			data.menuItem.addEventListener( 'mouseout', () =>
-				updateMenuItem( data )
-			);
+		// Listen for mouse and keyboard interactions.
+		data.menuItem.addEventListener('focusin', () => updateMenuItem(data));
+		data.menuItem.addEventListener('focusout', () => updateMenuItem(data));
+		data.menuItem.addEventListener('mouseover', () => updateMenuItem(data));
+		data.menuItem.addEventListener('mouseout', () => updateMenuItem(data));
 
-			// There's nothing more to do if this menu item has no submenu.
-			const submenuEl =
-				data.menuItem.querySelector( ':scope > .sub-menu' );
-			if ( ! submenuEl ) {
-				return;
+		// There's nothing more to do if this menu item has no submenu.
+		const submenuEl = data.menuItem.querySelector(':scope > .sub-menu');
+		if (!submenuEl) {
+			return;
+		}
+
+		// Cache submenu links.
+		data.links = submenuEl.querySelectorAll('a');
+
+		// Add a wrapper around the submenu for animating height transitions.
+		data.submenu = document.createElement('div');
+		data.submenu.classList.add('sub-menu-wrapper');
+		data.submenu.append(submenuEl);
+
+		// Add a submenu toggle button.
+		data.toggle = document.createElement('button');
+		data.toggle.classList.add('sub-menu-toggle');
+		data.toggle.addEventListener('click', () => {
+			if (data.isActive) {
+				deactivateMenuItem(data);
+			} else {
+				activateMenuItem(data);
 			}
+		});
 
-			// Cache submenu links.
-			data.links = submenuEl.querySelectorAll( 'a' );
-
-			// Add a wrapper around the submenu for animating height transitions.
-			data.submenu = document.createElement( 'div' );
-			data.submenu.classList.add( 'sub-menu-wrapper' );
-			data.submenu.append( submenuEl );
-
-			// Add a submenu toggle button.
-			data.toggle = document.createElement( 'button' );
-			data.toggle.classList.add( 'sub-menu-toggle' );
-			data.toggle.addEventListener( 'click', () => {
-				if ( data.isActive ) {
-					deactivateMenuItem( data );
-				} else {
-					activateMenuItem( data );
-				}
-			} );
-
-			// Insert the toggle before the submenu.
-			data.menuItem.append( data.toggle );
-			data.menuItem.append( data.submenu );
-		} );
+		// Insert the toggle before the submenu.
+		data.menuItem.append(data.toggle);
+		data.menuItem.append(data.submenu);
+	});
 
 	// Start closed.
 	hideMenu();
@@ -213,21 +282,21 @@ const menuIsMobile = () => {
  *
  * @param {Object} data The menu item data object from cache.menuItems.
  */
-const updateMenuItem = ( data ) => {
+const updateMenuItem = (data) => {
 	// On mobile, only open menu items when the associated toggle button is
 	// pressed.
-	if ( menuIsMobile() ) {
+	if (menuIsMobile()) {
 		return;
 	}
 
 	// On desktop, open menu items on :focus-within or :hover.
 	const shouldBeActive =
-		data.menuItem.matches( ':focus-within' ) ||
-		data.menuItem.matches( ':hover' );
-	if ( data.isActive && ! shouldBeActive ) {
-		deactivateMenuItem( data );
-	} else if ( ! data.isActive && shouldBeActive ) {
-		activateMenuItem( data );
+		data.menuItem.matches(':focus-within') ||
+		data.menuItem.matches(':hover');
+	if (data.isActive && !shouldBeActive) {
+		deactivateMenuItem(data);
+	} else if (!data.isActive && shouldBeActive) {
+		activateMenuItem(data);
 	}
 };
 
@@ -236,14 +305,14 @@ const updateMenuItem = ( data ) => {
  *
  * @param {Object} data The menu item data object from cache.menuItems.
  */
-const activateMenuItem = ( data ) => {
-	data.menuItem.classList.add( 'menu-item--is-active' );
-	if ( data.submenu ) {
-		data.submenu.setAttribute( 'aria-hidden', false );
-		data.toggle.setAttribute( 'aria-label', 'Hide submenu' );
-		data.links.forEach( ( link ) => {
-			link.removeAttribute( 'tabIndex' );
-		} );
+const activateMenuItem = (data) => {
+	data.menuItem.classList.add('menu-item--is-active');
+	if (data.submenu) {
+		data.submenu.setAttribute('aria-hidden', false);
+		data.toggle.setAttribute('aria-label', 'Hide submenu');
+		data.links.forEach((link) => {
+			link.removeAttribute('tabIndex');
+		});
 	}
 	data.isActive = true;
 };
@@ -253,41 +322,53 @@ const activateMenuItem = ( data ) => {
  *
  * @param {Object} data The menu item data object from cache.menuItems.
  */
-const deactivateMenuItem = ( data ) => {
-	data.menuItem.classList.remove( 'menu-item--is-active' );
-	if ( data.submenu ) {
-		data.submenu.setAttribute( 'aria-hidden', true );
-		data.toggle.setAttribute( 'aria-label', 'Show submenu' );
-		data.links.forEach( ( link ) => {
-			link.setAttribute( 'tabIndex', -1 );
-		} );
+const deactivateMenuItem = (data) => {
+	data.menuItem.classList.remove('menu-item--is-active');
+	if (data.submenu) {
+		data.submenu.setAttribute('aria-hidden', true);
+		data.toggle.setAttribute('aria-label', 'Show submenu');
+		data.links.forEach((link) => {
+			link.setAttribute('tabIndex', -1);
+		});
 	}
 	data.isActive = false;
 };
 
 const handleResize = () => {
-	// Find the site header height.
-	const siteHeader = document.querySelector( '.site-header' );
-	document.documentElement.style.setProperty(
-		'--site-header-height',
-		siteHeader.clientHeight + 'px'
-	);
+	measureSiteHeader();
 
-	const navElement = document.querySelector( '[data-js="main-nav"]' );
-	if ( state.v_width >= NAVIGATION_BREAKPOINT ) {
-		navElement.setAttribute( 'aria-hidden', 'false' );
+	const navElement = document.querySelector('[data-js="main-nav"]');
+	if (!navElement) {
 		return;
 	}
 
-	navElement.setAttribute( 'aria-hidden', 'true' );
+	if (state.v_width >= cache.desktopBreakpoint) {
+		// Leaving mobile with the menu open: close it so the body scroll lock
+		// doesn't leak into the desktop layout.
+		if (cache.navIsOpen) {
+			hideMenu();
+		}
+		navElement.setAttribute('aria-hidden', 'false');
+		return;
+	}
+
+	// Never stamp aria-hidden onto the open menu — mobile browsers fire
+	// resize while it's up (URL bar collapse, rotation, keyboard). Do keep
+	// the panel anchored to the header, which may have changed height.
+	if (cache.navIsOpen) {
+		measurePanelTop();
+		return;
+	}
+
+	navElement.setAttribute('aria-hidden', 'true');
 };
 
 const bindEvents = () => {
-	on( document, 'ucsc/resize_executed', handleResize );
+	on(document, 'ucsc/resize_executed', handleResize);
 };
 
 const init = () => {
-	if ( ! document.querySelector( '[data-js="main-nav"]' ) ) {
+	if (!document.querySelector('[data-js="main-nav"]')) {
 		return;
 	}
 

--- a/src/js/utils/body-lock.js
+++ b/src/js/utils/body-lock.js
@@ -21,7 +21,10 @@ const lock = () => {
 	locked = true;
 
 	style.position = 'fixed';
-	style.marginTop = `-${ scroll }px`;
+	style.marginTop = `-${scroll}px`;
+	// A fixed body with no explicit width sizes shrink-to-fit, which can
+	// exceed the viewport and shove right-anchored elements off-screen.
+	style.width = '100%';
 };
 
 /**
@@ -32,8 +35,10 @@ const lock = () => {
 const unlock = () => {
 	const style = document.body.style;
 
-	style.position = 'static';
-	style.marginTop = '0px';
+	// Clear the inline overrides entirely so stylesheet rules regain control.
+	style.position = '';
+	style.marginTop = '';
+	style.width = '';
 
 	scroller.scrollTop = scroll;
 	locked = false;

--- a/src/scss/theme-regions/_site-header.scss
+++ b/src/scss/theme-regions/_site-header.scss
@@ -4,33 +4,15 @@
 // Truss Header
 ////////////////////////////////////////////////////////////////////////////////
 
-// In order for the sticky header to show at the top of the viewport while
-// open on mobile, the Truss header above it needs to collapse.
+// NOTE: this scoped-CSS host class only exists in older Truss builds; the
+// current component is shadow-DOM encapsulated, so theme selectors cannot
+// reach inside it. The open mobile menu no longer depends on collapsing the
+// Truss header — the panel anchors to the header's measured bottom edge
+// instead (see main-nav.js and .site-header__navigation below).
 .sc-trss-ucsc-header-h {
 	display: grid;
 	grid-template-rows: 1fr;
-	transition: grid-template-rows 0.2s ease;
 	background-color: var(--wp--preset--color--ucsc-royal-blue);
-
-	.main-nav--is-open & {
-		grid-template-rows: 0fr;
-	}
-
-	.main-nav--is-open &,
-	.main-nav--is-closing & {
-
-		.trss-ucsc-header {
-			overflow: hidden;
-		}
-	}
-
-	.header-region--stuck & {
-		grid-template-rows: 1fr;
-
-		.trss-ucsc-header {
-			overflow: auto;
-		}
-	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,6 +30,14 @@
 	@include media-query($desktop-menu) {
 		background-color: var(--wp--preset--color--white);
 		overflow: visible;
+	}
+
+	// While the mobile menu is open, lift the header — and the menu panel and
+	// close button inside it — above everything else, including the Truss
+	// header's internal elements (which carry z-indexes up to 100).
+	.main-nav--is-open &,
+	.main-nav--is-closing & {
+		z-index: 1000;
 	}
 }
 
@@ -193,14 +183,31 @@
 	height: 0;
 	transition: height 0.2s ease;
 
-	// CASE: The mobile nav is open or opening.
-	.main-nav--is-open & {
-		height: calc(100svh - var(--site-header-height));
+	// CASE: The mobile nav is open, opening, or closing. Anchor the panel to
+	// the viewport, starting at the header's measured bottom edge
+	// (--nav-panel-top, set by main-nav.js at open time): with top + height
+	// derived from the same value, the panel bottom lands exactly on the
+	// viewport bottom edge, no matter what sits above the sticky header
+	// (the Truss header, alert banners, etc.).
+	.main-nav--is-open &,
+	.main-nav--is-closing & {
+		position: fixed;
+		top: var(--nav-panel-top, var(--site-header-height, 0px));
+		right: 0;
+		left: 0;
 	}
 
-	// CASE: The mobile nav's opening animation is complete and it is fully open.
-	.main-nav--is-open:not(.main-nav--is-opening) & {
-		overflow: auto;
+	// CASE: The mobile nav is open or opening. The panel is scrollable the
+	// moment it opens — gating overflow on the opening animation finishing
+	// left the menu permanently unscrollable when the height transition never
+	// completed. The var() fallbacks keep the calc valid (and the transition
+	// animatable) even if the measurements never ran.
+	.main-nav--is-open & {
+		height: calc(100svh - var(--nav-panel-top, var(--site-header-height, 0px)));
+		overflow-y: auto;
+		// Keep scroll gestures inside the panel; without this, hitting the
+		// panel's scroll boundary chains the gesture to the locked page.
+		overscroll-behavior: contain;
 	}
 
 	@include media-query($desktop-menu) {


### PR DESCRIPTION
This PR fixes #355, #393, and #394. The mobile nav menu was not working properly with long menus.

## Tests

1. Load the site on a mobile sized screen
2. Open the main menu
3. Toggle sub menus until the main menu extends below the bottom of the viewport
4. You should be able to scroll the menu to view items below the viewport